### PR TITLE
Create cumulative roads, buildings stats for all subhashtags

### DIFF
--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -317,6 +317,13 @@ function generateHashtagUrl (hashtag) {
   return `<a xlink:href="${hashtagUrl}" target="_blank" style="text-decoration: none">#${hashtag}</a>`;
 }
 
+// returns the total sum of the hashtg sum counts for buildings and roads in getGroupActivityStats
+function statsSum ( obj ) {
+  return Object.keys( obj ).reduce(function (sum, key) {
+    return sum + obj[key].value;
+  }, 0);
+}
+
 function getGroupActivityStats (hashtags, primaryHashtag) {
   // Connect hashtags to /group-summaries/ Missing Maps API endpoint
   const hashtagsString = [primaryHashtag].concat(hashtags).join(',');
@@ -332,14 +339,7 @@ function getGroupActivityStats (hashtags, primaryHashtag) {
                    hashtagsString + '. The partner graphs will not be displayed.');
     } else {
       const primaryData = hashtagData[primaryHashtag];
-      const primaryBuildingCount = primaryData.building_count_add + primaryData.building_count_mod;
-      const primaryRoadCount = primaryData.road_count_add + primaryData.road_count_mod;
 
-      // update the top-level stats in the hero
-      $('#stats-roadCount').html(primaryRoadCount.toLocaleString());
-      $('#stats-buildingCount').html(primaryBuildingCount.toLocaleString());
-      $('#stats-usersCount').html(primaryData.users.toLocaleString());
-      $('#stats-editsCount').html(primaryData.edits.toLocaleString());
 
       // For each hashtag, sum the total edits across all categories,
       // skipping over hashtags if there are no metrics (this shouldn't
@@ -375,6 +375,9 @@ function getGroupActivityStats (hashtags, primaryHashtag) {
         return acc;
       }, []).sort((a, b) => b.value - a.value);
 
+      // Sum all the building edits for all the subhashtags combined
+      const subhashtagsBldngCount = statsSum(bldngSum);
+
       // For each hashtag, sum the total road kilometers edited,
       // skipping over hashtags if there are no metrics
       const roadsSum = hashtags.reduce(function (acc, ht) {
@@ -386,6 +389,15 @@ function getGroupActivityStats (hashtags, primaryHashtag) {
         }
         return acc;
       }, []).sort((a, b) => b.value - a.value);
+
+      // Sum all the building edits for all the subhashtags combined
+      const subhashtagsRoadsCount = statsSum(roadsSum);
+
+            // update the top-level stats in the hero
+      $('#stats-roadCount').html(subhashtagsRoadsCount.toLocaleString());
+      $('#stats-buildingCount').html(subhashtagsBldngCount.toLocaleString());
+      $('#stats-usersCount').html(primaryData.users.toLocaleString());
+      $('#stats-editsCount').html(primaryData.edits.toLocaleString());
 
       // Spawn a chart function with listening events for each of the metrics
       var c1 = new Barchart(totalSum, '#Team-User-Total-Graph');

--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -586,7 +586,7 @@ function statsSum ( obj ) {
   }, 0);
 }
 
-function getGroupActivityStatsSalesforce (hashtags, primaryHashtag) {
+function getGroupActivityStatsSubHashtag (hashtags, primaryHashtag) {
   // Connect hashtags to /group-summaries/ Missing Maps API endpoint
   const hashtagsString = [primaryHashtag].concat(hashtags).join(',');
   const url = 'https://osm-stats-production-api.azurewebsites.net/group-summaries/' + hashtagsString;
@@ -716,7 +716,7 @@ checkHashtags(PT.subHashtags);
 setupGraphs();
 // Populates hero + initial groups graph via Missing Maps API
 if (PT.mainHashtag == 'salesforcels') {
-  getGroupActivityStatsSalesforce(PT.subHashtags, PT.mainHashtag);
+  getGroupActivityStatsSubHashtag(PT.subHashtags, PT.mainHashtag);
 } else {
   getGroupActivityStats(PT.subHashtags, PT.mainHashtag);
 }

--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -317,13 +317,6 @@ function generateHashtagUrl (hashtag) {
   return `<a xlink:href="${hashtagUrl}" target="_blank" style="text-decoration: none">#${hashtag}</a>`;
 }
 
-// returns the total sum of the hashtg sum counts for buildings and roads in getGroupActivityStats
-function statsSum ( obj ) {
-  return Object.keys( obj ).reduce(function (sum, key) {
-    return sum + obj[key].value;
-  }, 0);
-}
-
 function getGroupActivityStats (hashtags, primaryHashtag) {
   // Connect hashtags to /group-summaries/ Missing Maps API endpoint
   const hashtagsString = [primaryHashtag].concat(hashtags).join(',');
@@ -339,7 +332,14 @@ function getGroupActivityStats (hashtags, primaryHashtag) {
                    hashtagsString + '. The partner graphs will not be displayed.');
     } else {
       const primaryData = hashtagData[primaryHashtag];
+      const primaryBuildingCount = primaryData.building_count_add + primaryData.building_count_mod;
+      const primaryRoadCount = primaryData.road_count_add + primaryData.road_count_mod;
 
+      // update the top-level stats in the hero
+      $('#stats-roadCount').html(primaryRoadCount.toLocaleString());
+      $('#stats-buildingCount').html(primaryBuildingCount.toLocaleString());
+      $('#stats-usersCount').html(primaryData.users.toLocaleString());
+      $('#stats-editsCount').html(primaryData.edits.toLocaleString());
 
       // For each hashtag, sum the total edits across all categories,
       // skipping over hashtags if there are no metrics (this shouldn't
@@ -375,9 +375,6 @@ function getGroupActivityStats (hashtags, primaryHashtag) {
         return acc;
       }, []).sort((a, b) => b.value - a.value);
 
-      // Sum all the building edits for all the subhashtags combined
-      const subhashtagsBldngCount = statsSum(bldngSum);
-
       // For each hashtag, sum the total road kilometers edited,
       // skipping over hashtags if there are no metrics
       const roadsSum = hashtags.reduce(function (acc, ht) {
@@ -389,15 +386,6 @@ function getGroupActivityStats (hashtags, primaryHashtag) {
         }
         return acc;
       }, []).sort((a, b) => b.value - a.value);
-
-      // Sum all the building edits for all the subhashtags combined
-      const subhashtagsRoadsCount = statsSum(roadsSum);
-
-            // update the top-level stats in the hero
-      $('#stats-roadCount').html(subhashtagsRoadsCount.toLocaleString());
-      $('#stats-buildingCount').html(subhashtagsBldngCount.toLocaleString());
-      $('#stats-usersCount').html(primaryData.users.toLocaleString());
-      $('#stats-editsCount').html(primaryData.edits.toLocaleString());
 
       // Spawn a chart function with listening events for each of the metrics
       var c1 = new Barchart(totalSum, '#Team-User-Total-Graph');
@@ -591,6 +579,125 @@ function showAlternatePoster () {
   });
 }
 
+// returns the total sum of the hashtg sum counts for buildings and roads in getGroupActivityStats
+function statsSum ( obj ) {
+  return Object.keys( obj ).reduce(function (sum, key) {
+    return sum + obj[key].value;
+  }, 0);
+}
+
+function getGroupActivityStatsSalesforce (hashtags, primaryHashtag) {
+  // Connect hashtags to /group-summaries/ Missing Maps API endpoint
+  const hashtagsString = [primaryHashtag].concat(hashtags).join(',');
+  const url = 'https://osm-stats-production-api.azurewebsites.net/group-summaries/' + hashtagsString;
+
+  $.getJSON(url, function (hashtagData) {
+    // If no hashtags contain data, remove the partner graphs entirely
+    if ($.isEmptyObject(hashtagData)) {
+      $('.Team-User-Container').css('display', 'none');
+      console.warn('WARNING >> None of the secondary hashtags contain any ' +
+                   'metrics according to the Missing Maps endpoint at ' +
+                   'https://osm-stats-production-api.azurewebsites.net/group-summaries/' +
+                   hashtagsString + '. The partner graphs will not be displayed.');
+    } else {
+      const primaryData = hashtagData[primaryHashtag];
+
+
+      // For each hashtag, sum the total edits across all categories,
+      // skipping over hashtags if there are no metrics (this shouldn't
+      // happen at the API level, but good to use best-practices).
+      // The reduce patterns below are compareable to Array.prototype.map,
+      // with the difference that there does not need to be a 1:1 match
+      // between input and output array length
+      const hashtags = Object.keys(hashtagData).filter(x => x !== primaryHashtag);
+
+      const totalSum = hashtags.reduce(function (acc, ht) {
+        const vals = hashtagData[ht];
+        if (!$.isEmptyObject(vals)) {
+          const sum = vals.building_count_add +
+                      vals.building_count_mod +
+                      vals.road_count_add +
+                      vals.road_count_mod +
+                      vals.waterway_count_add +
+                      vals.poi_count_add;
+          acc.push({name: ht, decorate: generateHashtagUrl, value: sum});
+        }
+        return acc;
+      }, []).sort((a, b) => b.value - a.value);
+
+      // For each hashtag, sum the total building edits,
+      // skipping over hashtags if there are no metrics
+      const bldngSum = hashtags.reduce(function (acc, ht) {
+        const vals = hashtagData[ht];
+        if (!$.isEmptyObject(vals)) {
+          const sum = vals.building_count_add +
+                      vals.building_count_mod;
+          acc.push({name: ht, decorate: generateHashtagUrl, value: sum});
+        }
+        return acc;
+      }, []).sort((a, b) => b.value - a.value);
+
+      // Sum all the building edits for all the subhashtags combined
+      const subhashtagsBldngCount = statsSum(bldngSum);
+
+      // For each hashtag, sum the total road kilometers edited,
+      // skipping over hashtags if there are no metrics
+      const roadsSum = hashtags.reduce(function (acc, ht) {
+        const vals = hashtagData[ht];
+        if (!$.isEmptyObject(vals)) {
+          const sum = Math.round(vals.road_km_add +
+                      vals.road_km_mod);
+          acc.push({name: ht, decorate: generateHashtagUrl, value: sum});
+        }
+        return acc;
+      }, []).sort((a, b) => b.value - a.value);
+
+      // Sum all the building edits for all the subhashtags combined
+      const subhashtagsRoadsCount = statsSum(roadsSum);
+
+      const usersSum = hashtags.reduce(function (acc, ht) {
+        const vals = hashtagData[ht];
+        if (!$.isEmptyObject(vals)) {
+          const sum = vals.users;
+          acc.push({name: ht, decorate: generateHashtagUrl, value: sum});
+        }
+        return acc;
+      }, []).sort((a, b) => b.value - a.value);
+
+      const usersTotal = statsSum(usersSum);
+
+      const contributionsSum = hashtags.reduce(function (acc, ht) {
+        const vals = hashtagData[ht];
+        if (!$.isEmptyObject(vals)) {
+          const sum = vals.edits;
+          acc.push({name: ht, decorate: generateHashtagUrl, value: sum});
+        }
+        return acc;
+      }, []).sort((a, b) => b.value - a.value);
+
+      const editsTotal = statsSum(contributionsSum);
+
+            // update the top-level stats in the hero
+      $('#stats-roadCount').html(subhashtagsRoadsCount.toLocaleString());
+      $('#stats-buildingCount').html(subhashtagsBldngCount.toLocaleString());
+      $('#stats-usersCount').html(usersTotal.toLocaleString());
+      $('#stats-editsCount').html(editsTotal.toLocaleString());
+
+      // Spawn a chart function with listening events for each of the metrics
+      var c1 = new Barchart(totalSum, '#Team-User-Total-Graph');
+      var c2 = new Barchart(bldngSum, '#Team-User-Bldng-Graph');
+      var c3 = new Barchart(roadsSum, '#Team-User-Roads-Graph');
+
+      // On window resize, run window resize function on each chart
+      d3.select(window).on('resize', function () {
+        c1.resize();
+        c2.resize();
+        c3.resize();
+      });
+    }
+  });
+}
+
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  ---------------------------------------------------------
  --------------------- Setup Project ---------------------
@@ -608,7 +715,11 @@ checkHashtags(PT.subHashtags);
 // Sets up switcher/ loader for group and user graphs
 setupGraphs();
 // Populates hero + initial groups graph via Missing Maps API
-getGroupActivityStats(PT.subHashtags, PT.mainHashtag);
+if (PT.mainHashtag == 'salesforcels') {
+  getGroupActivityStatsSalesforce(PT.subHashtags, PT.mainHashtag);
+} else {
+  getGroupActivityStats(PT.subHashtags, PT.mainHashtag);
+}
 
 // Populate the Flickr carousel
 if (PT.flickrApiKey && PT.flickrSetId) {


### PR DESCRIPTION
Refer to #22 

Instead of displaying the number of edits from the primary hashtag, the top-level stats will display the sum of all the subhashtags (primary hashtag excluded)

When comparing to the missingmaps partner pages I noticed significant differences in the numbers. I'm fairly certain the logic for the math here is good, so please check that I am pulling the correct data in. For example I do not know how the hashtags are being used. I assumed that they exclusively used the primary and a single sub-hashtag. If they used only the primary hashtag, it was not counted. If they use 2 sub-hashtags, it was double-counted. As you can see this could get somewhat complicated. 